### PR TITLE
add alt atribute for <img> tags, in compliance with W3C-validator

### DIFF
--- a/layouts/partials/modals.html
+++ b/layouts/partials/modals.html
@@ -14,7 +14,7 @@
                     <div class="modal-body">
                         <h2>{{ .title }}</h2>
                         <hr class="star-primary">
-                        <img src="img/portfolio/{{ .img }}" class="img-responsive img-centered" alt="">
+			<img src="img/portfolio/{{ .img }}" class="img-responsive img-centered" alt="{{ .title }} image">
                         <p>{{ .description | markdownify }}</p>
                         <ul class="list-inline item-details">
                             <li>{{ with $.Site.Params.portfolio.modal.client }}{{.}}{{ end }}:

--- a/layouts/partials/portfolio-grid.html
+++ b/layouts/partials/portfolio-grid.html
@@ -16,7 +16,7 @@
                             <i class="fa fa-search-plus fa-3x"></i>
                         </div>
                     </div>
-                    <img src="img/portfolio/{{ .img }}" class="img-responsive">
+                    <img src="img/portfolio/{{ .img }}" class="img-responsive" alt="">
                 </a>
             </div>
             {{ end }}


### PR DESCRIPTION
Two minor fixes: 

1. The W3C validator is showing errors related to some missing `alt` attributes in `<img>` tags. These `alt` attributes have been added to the corresponding `<img>` tags.

2. Filled the `alt` attributes with the "project" title plus the word "image" as a value, in the project body display `<img>` tags.